### PR TITLE
refactor: Remove useless header update

### DIFF
--- a/src/Middleware/TrustHydraShield.php
+++ b/src/Middleware/TrustHydraShield.php
@@ -31,12 +31,7 @@ class TrustHydraShield extends TrustProxies
      */
     public function handle(Request $request, Closure $next)
     {
-        // We use CF-Connecting-IP instead of X-Forwarded-For since
-        // it has a consistent format containing only one IP.
-         $request->headers->set('X-Forwarded-For', $request->header('X-Forwarded-For'));
-
         Request::setTrustedProxies($this->proxies, $this->headers);
-
         return $next($request);
     }
 


### PR DESCRIPTION
Hello 👋 
X-Forwarded-For header is already assigned to a value. It's useless to assign it to the same value. 

# Proposed changes
- [x] Remove the header assignment to an already existing value

